### PR TITLE
flm-yp7: fix event handler index collision between event_at and register_event_handler

### DIFF
--- a/lib/filament/hooks.ex
+++ b/lib/filament/hooks.ex
@@ -439,6 +439,16 @@ defmodule Filament.Hooks do
   end
 
   @doc false
+  def set_event_handler_floor(n) when is_integer(n) do
+    case Process.get(:filament_render_context) do
+      nil -> :ok
+      ctx when ctx.event_handler_index < n ->
+        Process.put(:filament_render_context, %{ctx | event_handler_index: n})
+      _ -> :ok
+    end
+  end
+
+  @doc false
   @spec register_event_handler(handler :: function()) :: wire_ref :: String.t()
   def register_event_handler(handler) when is_function(handler) do
     ctx =

--- a/lib/filament/vnode_compiler.ex
+++ b/lib/filament/vnode_compiler.ex
@@ -277,8 +277,9 @@ defmodule Filament.VNodeCompiler do
   # and emits memo_at/event_at calls directly. Does NOT recurse into fn literals,
   # so only the linear render body is affected (not PLV comprehension entry fns).
   defp assign_and_emit(ast, rv) do
-    {result, _counters} = do_walk(ast, rv, {0, 0})
-    result
+    {result, {_t_ctr, e_ctr}} = do_walk(ast, rv, {0, 0})
+    floor_call = quote do: Filament.Hooks.set_event_handler_floor(unquote(e_ctr))
+    {:__block__, [], [floor_call, result]}
   end
 
   defp do_walk({:fn, _, _} = node, _rv, counters), do: {node, counters}

--- a/test/filament/vnode_compiler_test.exs
+++ b/test/filament/vnode_compiler_test.exs
@@ -193,6 +193,51 @@ defmodule Filament.VNodeCompilerTest do
     end
   end
 
+  describe "event_at / register_event_handler slot isolation" do
+    # Components with both on_* attributes on non-loop elements AND on_* handlers
+    # inside a {for} loop previously collided: register_event_handler reset its
+    # counter to 0 each render, overwriting event_at slots already written.
+    test "non-loop on_click handler is not overwritten by for-loop on_click handlers" do
+      defmodule MixedHandlerComp do
+        @moduledoc false
+        use Filament.Component
+
+        defcomponent MixedHandler do
+          def render(assigns) do
+            {_open, set_open} = use_state(true)
+
+            ~F"""
+            <div>
+              <button on_click={fn -> set_open.(false) end}>X</button>
+              {for {val, label} <- assigns.items do}
+                <li><a on_click={fn -> set_open.(val) end}>{label}</a></li>
+              {end}
+            </div>
+            """
+          end
+        end
+      end
+
+      items = [{:a, "A"}, {:b, "B"}, {:c, "C"}]
+
+      {tree, _rendered, _} =
+        Reconciler.mount(MixedHandlerComp.MixedHandler, %{items: items}, owner_pid: self())
+
+      close_handler = FiberTree.get_event_handler(tree, "root", 0)
+      loop_handler_0 = FiberTree.get_event_handler(tree, "root", 1)
+      loop_handler_1 = FiberTree.get_event_handler(tree, "root", 2)
+      loop_handler_2 = FiberTree.get_event_handler(tree, "root", 3)
+
+      assert is_function(close_handler), "slot 0 must hold the X-button close handler"
+      assert is_function(loop_handler_0), "slot 1 must hold the first loop handler"
+      assert is_function(loop_handler_1), "slot 2 must hold the second loop handler"
+      assert is_function(loop_handler_2), "slot 3 must hold the third loop handler"
+
+      refute close_handler === loop_handler_0,
+             "X-button handler must not be overwritten by the first loop handler"
+    end
+  end
+
   describe "comprehension memoization" do
     test "for-loop with handlers reuses result when outer-scope deps unchanged" do
       defmodule CompMemoComp do


### PR DESCRIPTION
## Problem

Components with both `on_*` attributes on non-loop elements and `on_*` handlers inside a `{for}` loop silently dispatched events to the wrong handlers. `register_event_handler` (used by hoisted for-loop handlers) reset its counter to 0 each render, overwriting `event_at` slots already assigned by the compiler.

Clicking an X button would call the first list item's handler instead.

## Fix

- **`hooks.ex`**: Add `set_event_handler_floor/1` — bumps `event_handler_index` up to `n` if it's currently below it, no-op otherwise.
- **`vnode_compiler.ex`**: `assign_and_emit/2` now captures the final `e_ctr` from `do_walk` and prepends a `set_event_handler_floor(e_ctr)` call to the compiled template body, ensuring `register_event_handler` always starts above all compile-time `event_at` slots.

~10 lines added. No wire ref format changes, no breaking changes.

## Test plan

- [x] New test `"non-loop on_click handler is not overwritten by for-loop on_click handlers"` in `vnode_compiler_test.exs` — was failing before, passes after
- [x] Full suite: 314 tests, 0 failures