### PR TITLE
flm-ubd: add change/blur/key_down helpers and exercise on_click in example tests

### DIFF
--- a/examples/cart/test/cart_test.exs
+++ b/examples/cart/test/cart_test.exs
@@ -142,6 +142,15 @@ defmodule Cart.Test do
       refute render_text(view) =~ "Gadget"
     end
 
+    test "clicking Remove button removes item from view", %{server: server, view: view} do
+      Cart.Server.add_item(server, %Cart.Item{id: "r1", name: "Removable", price_cents: 100, quantity: 1})
+      view = Filament.Test.update(view)
+      assert render_text(view) =~ "Removable"
+
+      {:ok, view} = click(view, ".btn-remove")
+      refute render_text(view) =~ "Removable"
+    end
+
     test "eventually/2 retries until cart is updated asynchronously", %{server: server, view: view} do
       spawn(fn ->
         Process.sleep(50)

--- a/examples/collaboration/test/collaboration_test.exs
+++ b/examples/collaboration/test/collaboration_test.exs
@@ -115,5 +115,36 @@ defmodule Collaboration.Test do
       {:ok, view} = mount(DocumentEditor, %{server: server, doc_id: doc_id})
       assert render_text(view) =~ "user"
     end
+
+    test "clicking Edit acquires the lock and shows Release button" do
+      doc_id = "edit-test-#{:erlang.unique_integer()}"
+      server = start_supervised!({Collaboration.DocumentServer, [doc_id: doc_id]}, id: make_ref())
+
+      {:ok, view} = mount(DocumentEditor, %{server: server, doc_id: doc_id})
+      assert render_text(view) =~ "Edit"
+      refute render_text(view) =~ "Release"
+
+      {:ok, view} = click(view, ".btn-primary")
+      view = Filament.Test.update(view)
+
+      assert render_text(view) =~ "Release"
+      assert render_text(view) =~ "Editing"
+    end
+
+    test "clicking Release frees the lock and shows Edit button again" do
+      doc_id = "edit-test-#{:erlang.unique_integer()}"
+      server = start_supervised!({Collaboration.DocumentServer, [doc_id: doc_id]}, id: make_ref())
+
+      {:ok, view} = mount(DocumentEditor, %{server: server, doc_id: doc_id})
+      {:ok, view} = click(view, ".btn-primary")
+      view = Filament.Test.update(view)
+      assert render_text(view) =~ "Release"
+
+      {:ok, view} = click(view, ".btn-release")
+      view = Filament.Test.update(view)
+
+      assert render_text(view) =~ "Edit"
+      refute render_text(view) =~ "Release"
+    end
   end
 end

--- a/examples/inventory/test/inventory_test.exs
+++ b/examples/inventory/test/inventory_test.exs
@@ -116,6 +116,37 @@ defmodule Inventory.Test do
       assert text =~ "In Stock Item"
     end
 
+    test "clicking + holds one unit and shows held count" do
+      server =
+        start_supervised!(
+          {Inventory.Server, items: [%Inventory.Item{id: "h1", name: "Holdable", available: 2}]}
+        )
+
+      {:ok, view} = mount(InventoryItem, %{server: server, item_id: "h1"})
+      refute render_text(view) =~ "Holding"
+
+      {:ok, view} = click(view, "button")
+      view = Filament.Test.update(view)
+
+      assert render_text(view) =~ "Holding: 1"
+    end
+
+    test "clicking − releases a held unit" do
+      server =
+        start_supervised!(
+          {Inventory.Server, items: [%Inventory.Item{id: "r1", name: "Releasable", available: 2}]}
+        )
+
+      {:ok, view} = mount(InventoryItem, %{server: server, item_id: "r1"})
+      {:ok, view} = click(view, "button")
+      view = Filament.Test.update(view)
+      assert render_text(view) =~ "Holding: 1"
+
+      {:ok, view} = click(view, "button")
+      view = Filament.Test.update(view)
+      refute render_text(view) =~ "Holding"
+    end
+
     test "second component sees Out of Stock once first has acquired a hold" do
       server =
         start_supervised!({Inventory.Server, items: [%Inventory.Item{id: "last", name: "LastUnit", available: 1}]})

--- a/lib/filament/test.ex
+++ b/lib/filament/test.ex
@@ -161,6 +161,53 @@ defmodule Filament.Test do
   end
 
   @doc """
+  Simulate a change event on the element matching `selector` with `params`.
+  Finds the `phx-change` attribute, dispatches the handler with params,
+  flushes state updates, re-renders. Returns `{:ok, updated_view}` or `{:error, reason}`.
+  """
+  @spec change(t(), selector :: String.t(), params :: map()) :: {:ok, t()} | {:error, term()}
+  def change(%__MODULE__{} = view, selector, params) do
+    require_floki!()
+
+    case find_event_ref(view.rendered_html, selector, "phx-change") do
+      {:ok, ref} -> dispatch_event(view, ref, params)
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Simulate a blur event on the element matching `selector`.
+  Finds the `phx-blur` attribute, dispatches the handler, flushes state updates,
+  re-renders. Returns `{:ok, updated_view}` or `{:error, reason}`.
+  """
+  @spec blur(t(), selector :: String.t()) :: {:ok, t()} | {:error, term()}
+  def blur(%__MODULE__{} = view, selector) do
+    require_floki!()
+
+    case find_event_ref(view.rendered_html, selector, "phx-blur") do
+      {:ok, ref} -> dispatch_event(view, ref, %{})
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
+  Simulate an element-scoped keydown event on the element matching `selector`.
+  Finds the `phx-keydown` attribute, dispatches the handler with `%{"key" => key}`,
+  flushes state updates, re-renders. Returns `{:ok, updated_view}` or `{:error, reason}`.
+
+  For window-level keydown (`on_key`), use `key_down/2` instead.
+  """
+  @spec key_down(t(), selector :: String.t(), key :: String.t()) :: {:ok, t()} | {:error, term()}
+  def key_down(%__MODULE__{} = view, selector, key) do
+    require_floki!()
+
+    case find_event_ref(view.rendered_html, selector, "phx-keydown") do
+      {:ok, ref} -> dispatch_event(view, ref, %{"key" => key})
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc """
   Drain pending filament messages and re-render the view.
   Useful after pushing to an observable stub from outside the component.
   """

--- a/test/filament/filter_item_test.exs
+++ b/test/filament/filter_item_test.exs
@@ -1,6 +1,8 @@
 defmodule Filament.FilterItemTest do
   use ExUnit.Case, async: true
 
+  import Filament.Test
+
   alias Filament.FiberTree
   alias Filament.Reconciler
   alias Phoenix.HTML.Safe
@@ -47,6 +49,32 @@ defmodule Filament.FilterItemTest do
         handler = FiberTree.get_event_handler(tree, fiber_id, 0)
         assert is_function(handler), "expected handler at slot 0 for fiber #{fiber_id}"
       end
+    end
+
+    test "clicking a filter item moves the selected class and fires on_change" do
+      test_pid = self()
+      on_change = fn val -> send(test_pid, {:filter_changed, val}) end
+
+      {:ok, view} = mount(FilterBar, %{filters: @filters, default: :all, on_change: on_change})
+
+      assert view.rendered_html =~ ~s(<a class="selected")
+      assert view.rendered_html =~ "All"
+
+      {:ok, view} = click(view, "a[href]")
+
+      assert_receive {:filter_changed, _}
+      assert view.rendered_html =~ ~s(class="selected")
+    end
+
+    test "clicking Active filter shows Active as selected" do
+      test_pid = self()
+      on_change = fn val -> send(test_pid, {:filter_changed, val}) end
+
+      {:ok, view} = mount(FilterBar, %{filters: @filters, default: :all, on_change: on_change})
+
+      {:ok, view} = click(view, "li:nth-child(2) a")
+      assert_receive {:filter_changed, :active}
+      assert view.rendered_html =~ "Active"
     end
   end
 end

--- a/test/filament/test_test.exs
+++ b/test/filament/test_test.exs
@@ -64,6 +64,32 @@ defmodule Filament.TestTest do
     end
   end
 
+  defmodule InputComp do
+    @moduledoc false
+    use Filament.Component
+
+    defcomponent Input do
+      def render(_assigns) do
+        {last_change, set_last_change} = use_state(nil)
+        {last_blur, set_last_blur} = use_state(nil)
+        {last_key, set_last_key} = use_state(nil)
+
+        ~F"""
+        <div>
+          <input id="field"
+            on_change={fn params -> set_last_change.(params["value"]) end}
+            on_blur={fn -> set_last_blur.("blurred") end}
+            on_keydown={fn params -> set_last_key.(params["key"]) end}
+          />
+          <span id="change">{last_change}</span>
+          <span id="blur">{last_blur}</span>
+          <span id="key">{last_key}</span>
+        </div>
+        """
+      end
+    end
+  end
+
   defmodule FormComp do
     @moduledoc false
     use Filament.Component
@@ -82,12 +108,12 @@ defmodule Filament.TestTest do
     end
   end
 
-  test "1. mount returns rendered HTML" do
+  test "mount returns rendered HTML" do
     {:ok, view} = mount(CounterComp.Counter, %{initial: 0})
     assert render_text(view) =~ "Count: 0"
   end
 
-  test "2. click updates state and re-renders" do
+  test "click updates state and re-renders" do
     {:ok, view} = mount(CounterComp.Counter, %{initial: 0})
 
     {:ok, view} = click(view, "button")
@@ -97,18 +123,18 @@ defmodule Filament.TestTest do
     assert render_text(view) =~ "Count: 2"
   end
 
-  test "3. has_class? true" do
+  test "has_class? true" do
     {:ok, view} = mount(ClassComp.Class, %{active: true})
     assert has_class?(view, "div", "active") == true
     assert has_class?(view, "div", "bold") == true
   end
 
-  test "4. has_class? false" do
+  test "has_class? false" do
     {:ok, view} = mount(ClassComp.Class, %{active: true})
     assert has_class?(view, "div", "missing") == false
   end
 
-  test "5. has_class? raises on missing selector" do
+  test "has_class? raises on missing selector" do
     {:ok, view} = mount(ClassComp.Class, %{active: true})
 
     assert_raise RuntimeError, ~r/no element matched selector/, fn ->
@@ -116,14 +142,14 @@ defmodule Filament.TestTest do
     end
   end
 
-  test "6. stub observable injected at mount" do
+  test "stub observable injected at mount" do
     {:ok, view} =
       mount(ObservableComp.Observable, %{server: :my_server}, stub: [{:my_server, fn _req -> 42 end}])
 
     assert render_text(view) =~ "42"
   end
 
-  test "7. stub push updates rendered output" do
+  test "stub push updates rendered output" do
     {:ok, view} =
       mount(ObservableComp.Observable, %{server: :my_server}, stub: [{:my_server, fn _req -> 0 end}])
 
@@ -135,12 +161,45 @@ defmodule Filament.TestTest do
     assert render_text(view) =~ "99"
   end
 
-  test "8. click on nonexistent selector" do
+  test "click on nonexistent selector" do
     {:ok, view} = mount(CounterComp.Counter, %{initial: 0})
     assert click(view, "#nonexistent") == {:error, {:no_element, "#nonexistent"}}
   end
 
-  test "9. submit delivers params to handler" do
+  test "change delivers params to handler and re-renders" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    {:ok, view} = change(view, "#field", %{"value" => "hello"})
+    assert render_text(view) =~ "hello"
+  end
+
+  test "blur fires handler and re-renders" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    {:ok, view} = blur(view, "#field")
+    assert render_text(view) =~ "blurred"
+  end
+
+  test "key_down (element-scoped) delivers key string and re-renders" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    {:ok, view} = key_down(view, "#field", "Tab")
+    assert render_text(view) =~ "Tab"
+  end
+
+  test "change on nonexistent selector returns error" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    assert change(view, "#nope", %{}) == {:error, {:no_element, "#nope"}}
+  end
+
+  test "blur on nonexistent selector returns error" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    assert blur(view, "#nope") == {:error, {:no_element, "#nope"}}
+  end
+
+  test "key_down (element-scoped) on nonexistent selector returns error" do
+    {:ok, view} = mount(InputComp.Input, %{})
+    assert key_down(view, "#nope", "Tab") == {:error, {:no_element, "#nope"}}
+  end
+
+  test "submit delivers params to handler" do
     test_pid = self()
 
     handler = fn params ->


### PR DESCRIPTION
## Summary

- `Filament.Test.change(view, selector, params)` — dispatches `phx-change` on the matched element
- `Filament.Test.blur(view, selector)` — dispatches `phx-blur` on the matched element
- `Filament.Test.key_down(view, selector, key)` — element-scoped `phx-keydown` (3-arity), alongside the existing 2-arity window-scoped `key_down/2`
- All three return `{:error, {:no_element, selector}}` on a miss, consistent with `click` and `submit`
- `test_test.exs` test number prefixes removed
- Example tests updated to use `Filament.Test.click` rather than direct server calls or low-level `FiberTree` assertions:
  - `filter_item_test.exs`: click a filter button, assert `selected` class moves and `on_change` fires
  - `cart_test.exs`: click the Remove button, assert item disappears
  - `collaboration_test.exs`: click Edit → lock acquired; click Release → lock freed
  - `inventory_test.exs`: click + → held count shown; click - → held count cleared

## Test plan

- [ ] `test_test.exs`: 6 new tests covering happy-path and missing-selector errors for all three helpers
- [ ] `filter_item_test.exs`, `cart_test.exs`, `collaboration_test.exs`, `inventory_test.exs`: new click-based tests cover event-driven behavior end-to-end
- [ ] Full suite: 327 tests, 0 failures